### PR TITLE
Modify microc toplevel

### DIFF
--- a/src/toplevel.ml
+++ b/src/toplevel.ml
@@ -1,0 +1,23 @@
+(* Top-level of the TensorFlock compiler: scan & parse the input *)
+
+type action = Ast | LLVM_IR | Compile
+
+let () =
+  let action = ref Compile in
+  let set_action a () = action := a in
+  let speclist = [
+    ("-a", Arg.Unit (set_action Ast), "Print the AST");
+    ("-l", Arg.Unit (set_action LLVM_IR), "Print the generated LLVM IR");
+    ("-c", Arg.Unit (set_action Compile),
+      "Check and print the generated LLVM IR (default)");
+  ] in  
+  let usage_msg = "usage: ./toplevel.native [-a|-l|-c] [file.tf]" in
+  let channel = ref stdin in
+  Arg.parse speclist (fun filename -> channel := open_in filename) usage_msg;
+  
+  let lexbuf = Lexing.from_channel !channel in
+  let ast = Parser.program Scanner.token lexbuf in  
+  match !action with
+     Ast -> print_string (Ast.string_of_program ast)
+   | LLVM_IR -> print_string ("Not implemented")  
+   | Compile -> print_string ("Not implemented")  


### PR DESCRIPTION
Took out SAST and left placeholder "not implemented" messages for Compile and LLVM steps