### PR TITLE
Setup Docker for local dev

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,6 +1,6 @@
 pipeline:
   test:
-    image: nbuonin/ocaml4.06-llvm3.6:latest
+    image: nbuonin/ocaml4.06-llvm3.8:latest
     pull: true
     commands:
       - touch opam

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,16 @@ ifneq ($(wildcard *.zip),)
 	rm -f *.zip 
 endif
 
-docker:
-	docker build -t nbuonin/ocaml4.06-llvm3.6 docker
+docker-build-image:
+	docker build -t nbuonin/ocaml4.06-llvm3.8 docker
 
-.PHONY: state test clean zip docker demo
+docker-shell:
+	docker run --rm -it -v `pwd`:/root/TensorFlock -w=/root/TensorFlock --entrypoint=/bin/bash nbuonin/ocaml4.06-llvm3.6
+
+docker-make:
+	docker run --rm -it -v `pwd`:/root/TensorFlock -w=/root/TensorFlock --entrypoint="" nbuonin/ocaml4.06-llvm3.6 make
+
+docker-make-test:
+	docker run --rm -it -v `pwd`:/root/TensorFlock -w=/root/TensorFlock --entrypoint="" nbuonin/ocaml4.06-llvm3.6 make test
+
+.PHONY: state test clean zip docker demo docker-shell docker-make docker-make-test


### PR DESCRIPTION
This commit adds make targets to run various tasks inside a Docker
container. It permits:
- "make" => "make docker-make"
- "make test" => "make docker-make-test"
- "make docker-shell" drops you into the shell in the project directory

Note that though files written in the work directory will persist, any
other modifications to the container are trashed upon exit.

Lastly, this commit corrects the name of the Docker image to correctly
reflect the installed version of llvm.