### PR TITLE
Fix clean target to remove *.native

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,9 @@ zip: clean
 
 clean: 
 	ocamlbuild -clean
+ifneq ($(wildcard *.native),)
+	rm *.native
+endif
 ifneq ($(wildcard *.ll),)
 	rm *.ll
 endif


### PR DESCRIPTION
This commit sets `make clean` to remove the symlink to `toplevel.native`
if compiled with Docker.