### PR TITLE
Remove commas from tensor literal initialization

### DIFF
--- a/src/parser.mly
+++ b/src/parser.mly
@@ -129,7 +129,7 @@ tcontents:
        /* literals can be accomplished by replacing lexpr in */
        /* the following two lines with expr */ 
        lexpr { [$1] }
-   | tcontents COMMA lexpr { $3 :: $1 }
+   | tcontents lexpr { $2 :: $1 }
 
 
 shape:

--- a/tests/syntax_tests/pass5.tf
+++ b/tests/syntax_tests/pass5.tf
@@ -15,7 +15,7 @@ f2 = f1 d[i,j] + 1;
 
 // Tensor initialization and function declaration
 initialized_tensor : T<a>; 
-initialized_tensor = [[[1.0 , 2.0, 3.0], [3.0,4.0,5.0], [6.0,7.0,8.0]]];
+initialized_tensor = [[[1.0   2.0  3.0]  [3.0 4.0 5.0]  [6.0 7.0 8.0]]];
 
 fn : T<1,2>;
 fn arg1 arg2 = arg1[i,j];


### PR DESCRIPTION
It turns out that it's as simple as deleting the COMMA token from
tcontents in the parser and changing the relevant test file