### PR TITLE
Set Docker image version

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,6 +1,6 @@
 pipeline:
   test:
-    image: nbuonin/ocaml4.06-llvm3.8:latest
+    image: nbuonin/ocaml4.06-llvm3.8:v1
     pull: true
     commands:
       - touch opam

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,9 @@ PROJECT_PARSER ?= parser
 OPAM_FILE ?= opam
 COMPILER_FLAGS = -cflag -warn-error=+A-4-42-27
 COMPILER_PACKAGES = -use-ocamlfind -package llvm,llvm.analysis,llvm.bitwriter 
+
+# Docker: after updating the Dockerfile, build a new image and tag with an
+# incremented version number. Also update the version in .drone.yml
 DOCKER_IMAGE = nbuonin/ocaml4.06-llvm3.8
 DOCKER_TAG = v1
 


### PR DESCRIPTION
This commit assigns a version number to the Docker image. Each time a
new Docker image is created we should bump the version here to ensure
that the newest image is pulled when docker* targets are run.