### PR TITLE
Optimize build process so that it doesn't run clean unnecessarily

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,9 +21,9 @@ $(OCAML_SENTINAL): $(OPAM_FILE)
 	opam install --deps-only $(PROJECT)
 	touch $@
 
-$(PROJECT_TOP): $(OCAML_SENTINAL) clean $(SRC_DIR)*
+$(PROJECT_TOP): $(OCAML_SENTINAL) $(SRC_DIR)*
 	ocamlbuild $(COMPILER_FLAGS) $(COMPILER_PACKAGES) $(PROJECT_EXTENSION)
-	clang -c $(SRC_DIR)runtime.c -o runtime.o
+	clang -c $(SRC_DIR)runtime.c -o _build/src/runtime.o
 
 state: $(OCAML_SENTINAL) clean
 	ocamlyacc -v $(SRC_DIR)$(PROJECT_PARSER).mly

--- a/test_runner.sh
+++ b/test_runner.sh
@@ -32,7 +32,7 @@ function run_test {
     if [ $2 == "c" ]
     then
         llc output.ll
-        clang -Wno-override-module -lm  output.s runtime.o -o output
+        clang -Wno-override-module -lm  output.s _build/src/runtime.o -o output
         generated_output=$(./output)
     fi
 


### PR DESCRIPTION
Fix #107 by removing the call to clean in the makefile and moving runtime.o into the generated _build/ directory so that ocamlbuild doesn't complain about the presence of a .o file in the root directory.