### PR TITLE
Add man pages and valgrind to docker image

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,6 +1,6 @@
 pipeline:
   test:
-    image: nbuonin/ocaml4.06-llvm3.8:v1
+    image: nbuonin/ocaml4.06-llvm3.8:v2
     pull: true
     commands:
       - touch opam

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ COMPILER_PACKAGES = -use-ocamlfind -package llvm,llvm.analysis,llvm.bitwriter
 # Docker: after updating the Dockerfile, build a new image and tag with an
 # incremented version number. Also update the version in .drone.yml
 DOCKER_IMAGE = nbuonin/ocaml4.06-llvm3.8
-DOCKER_TAG = v1
+DOCKER_TAG = v2
 
 SHELL=/bin/sh
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -36,4 +36,7 @@ RUN ln -s /usr/bin/lli-3.8 /usr/bin/lli
 RUN ln -s /usr/bin/llc-3.8 /usr/bin/llc
 RUN ln -s /usr/bin/clang-3.8 /usr/bin/clang
 
+# Installing handy packages
+RUN apt-get install -y man-db valgrind
+
 ENTRYPOINT ["/bin/bash"]


### PR DESCRIPTION
- The watcher script isn't so portable, stat uses different format
strings on OSX and Ubuntu, I didn't want to spend too much time on this,
so I'll let it go
- man pages are installed
- valgrind is installed
- LLVM suffix free: its strange, they are already symlinked correctly,
but they don't work in the container.  Again I didn't spend too much
time on this, but for now we have everything we need
- gcc extension for emitting LLVM, AFAICT this project died in 2012,
prob over licensing differences, we can however get assembly from gcc
like so: `gcc -S -O0 somefile.c`