### PR TITLE
Add watch script, attach command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,9 @@ ifneq ($(wildcard *.s),)
 	rm -f *.s 
 endif
 
+watch:
+	./watch.sh $(SRC_DIR)
+
 docker-build-image:
 	docker build -t $(DOCKER_IMAGE) docker
 
@@ -79,6 +82,10 @@ docker-make:
 
 docker-test:
 	docker run --rm -it -v `pwd`:/root/TensorFlock -w=/root/TensorFlock --entrypoint="" $(DOCKER_IMAGE):$(DOCKER_TAG) make test
+
+docker-attach:
+	@echo "Use ctrl-c to detach from running container"
+	docker exec -it --detach-keys="ctrl-c" -w=/root/TensorFlock `docker ps --latest --filter ancestor=$(DOCKER_IMAGE):$(DOCKER_TAG) --filter status=running --format "{{.ID}}"` bash
 
 # if lli isn't on the path, try to set it from a var, else warn user end exit
 llvm:

--- a/watch.sh
+++ b/watch.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+if [ $(uname) == "Darwin" ]
+then
+    STAT_STR="stat -f %c"
+else
+    STAT_STR="stat --format=%Z"
+fi
+
+DIR_M_TIME=$($STAT_STR $1) ;
+while true 
+do 
+    TEMP_TIME=$($STAT_STR $1); 
+	if [ "$DIR_M_TIME" != "$TEMP_TIME" ]; 
+	then 
+	  make 
+	  DIR_M_TIME=$TEMP_TIME; 
+    fi; 
+    sleep 3; 
+done;


### PR DESCRIPTION
This commit:
- Adds a `make watch` target on the src directory for easy rebuilding
- Adds a `make docker-attach` target to open a shell in the most recent
running container. This could be handy if you're running `make watch` in
one window but would like access into the container from another window.